### PR TITLE
 [docs] improved README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ More information: https://web.archive.org/web/20170129010544/https://blog.liftse
 
 Examples: [test/rules/tsr-detect-child-process/default/test.ts.lint](test/rules/tsr-detect-child-process/default/test.ts.lint)
 
-#### `tsr-detect-disable-mustache-escape`
+#### `tsr-disable-mustache-escape`
 
 Detects `object.escapeMarkup = false`, which can be used with some template engines to disable escaping of HTML entities. This can lead to Cross-Site Scripting (XSS) vulnerabilities.
 


### PR DESCRIPTION
Fixes header for `tsr-disable-mustache-escape`. This rule does not conform to the other format as it's `tsr-disable..` instead of `tsr-detect-disable...` but that's a breaking change so this just updates the docs for consistency